### PR TITLE
chore(DDH-12): update filter disaster type and change to single selection

### DIFF
--- a/src/components/MapLabel.jsx
+++ b/src/components/MapLabel.jsx
@@ -8,7 +8,7 @@ export const MapLabel = ({ selectedDisaster, selectedInformation }) => {
   return (
     <Flex className="flex-col items-end gap-3 py-2 px-6 bg-white rounded-md">
       <Transition
-        mounted={selectedDisaster.includes("flood")}
+        mounted={selectedDisaster === "flood"}
         transition="fade-right"
         duration={400}
         timingFunction="ease"
@@ -30,7 +30,7 @@ export const MapLabel = ({ selectedDisaster, selectedInformation }) => {
       </Transition>
 
       <Transition
-        mounted={selectedDisaster.includes("mudslide")}
+        mounted={selectedDisaster === "mudslide"}
         transition="fade-right"
         duration={400}
         timingFunction="ease"

--- a/src/components/filter/index.jsx
+++ b/src/components/filter/index.jsx
@@ -38,11 +38,7 @@ const Filter = () => {
                   )}
                   onClick={() => {
                     if (isEnable) {
-                      if (isSelected) {
-                        setSelectedDisaster(undefined);
-                      } else {
-                        setSelectedDisaster(item.value);
-                      }
+                      setSelectedDisaster(isSelected ? undefined : item.value);
                     }
                   }}
                 >

--- a/src/components/filter/index.jsx
+++ b/src/components/filter/index.jsx
@@ -7,6 +7,7 @@ import {
   DISASTER_TYPE,
   DISTRICT_OPTIONS,
   SUBDISTRICT_OPTIONS,
+  DISASTER_TYPE_ENABLE,
 } from "../../constants/index";
 import Level from "./Level";
 
@@ -21,7 +22,8 @@ const Filter = () => {
           <Level />
           <div className="row gap-2">
             {DISASTER_TYPE.map((item) => {
-              const isSelected = selectedDisaster.includes(item.value);
+              const isSelected = selectedDisaster === item.value;
+              const isEnable = DISASTER_TYPE_ENABLE.includes(item.value);
               return (
                 <Button
                   key={item.value}
@@ -31,15 +33,16 @@ const Filter = () => {
                     {
                       "text-blue-500 font-[500] border-blue-100 bg-blue-100":
                         isSelected,
+                      "cursor-default": !isEnable,
                     }
                   )}
                   onClick={() => {
-                    if (isSelected) {
-                      setSelectedDisaster(
-                        selectedDisaster.filter((j) => j !== item.value)
-                      );
-                    } else {
-                      setSelectedDisaster(selectedDisaster.concat(item.value));
+                    if (isEnable) {
+                      if (isSelected) {
+                        setSelectedDisaster(undefined);
+                      } else {
+                        setSelectedDisaster(item.value);
+                      }
                     }
                   }}
                 >
@@ -53,7 +56,7 @@ const Filter = () => {
           ข้อมูล​ ณ วันที่ 29 ต.ค. 2024 - 4 พ.ย. 2024
         </p>
       </div>
-      <div className="col gap-1 absolute left-[684px] top-[144px] z-30">
+      <div className="col gap-1 absolute left-[784px] top-[144px] z-30">
         <Select
           value={search?.district ?? null}
           withCheckIcon={false}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -94,11 +94,15 @@ export const DISASTERS = [
 
 export const DISASTER_TYPE = [
   { label: "อุทกภัย", value: "flood" },
+  { label: "PM2.5", value: "PM2.5" },
   { label: "ดินโคลนถล่ม", value: "mudslide" },
   { label: "วาตภัย", value: "storm" },
   { label: "ภัยแล้ง", value: "drought" },
   { label: "อัคคีภัย", value: "fire" },
+  { label: "แผ่นดินไหว/สึนามิ", value: "earthquake" },
 ];
+
+export const DISASTER_TYPE_ENABLE = ["flood", "PM2.5"];
 
 export const DISTRICT_OPTIONS = [
   {

--- a/src/contexts/mainContext.jsx
+++ b/src/contexts/mainContext.jsx
@@ -4,7 +4,7 @@ import { createContext, useState } from "react";
 export const MainContext = createContext(null);
 
 const MainContextProvider = ({ children }) => {
-  const [selectedDisaster, setSelectedDisaster] = useState([]);
+  const [selectedDisaster, setSelectedDisaster] = useState();
   const [search, setSeach] = useState();
 
   const onChangeSearch = (value) => {


### PR DESCRIPTION
Issues No. [DDH-12](https://www.notion.so/Add-on-UI-Disaster-type-189e46eb29bb803c88d0ec1be8b62171)

# Overview
- update disaster type in filter section
- single selection
- enable select only อุทกภัย PM2.5

# UI from Implement

https://github.com/user-attachments/assets/4b22f2fc-eb79-45f5-a6ff-a4c6d0729616


# UI from Figma
